### PR TITLE
詳細ページの実装、条件分岐による表示の変更

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -20,6 +20,10 @@ class ProductsController < ApplicationController
     end
   end
 
+  def show
+    @product = Product.find(params[:id])
+  end
+
 
 
 

--- a/app/models/shipment_day.rb
+++ b/app/models/shipment_day.rb
@@ -1,9 +1,9 @@
 class ShipmentDay < ActiveHash::Base
   self.data = [
     { id: 1, name: '選択してください' },
-    { id: 2, name: '1〜2で発送' },
-    { id: 3, name: '2〜3で発送' },
-    { id: 4, name: '4〜7で発送' }
+    { id: 2, name: '1〜2日で発送' },
+    { id: 3, name: '2〜3日で発送' },
+    { id: 4, name: '4〜7日で発送' }
   ]
 
   include ActiveHash::Associations

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -128,7 +128,7 @@
     <% if  @products[0] != nil %>
       <% @products.each do |product| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to product_path(product.id) do %>
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" %>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -28,9 +28,7 @@
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-<% end %>
-   
-    <% if user_signed_in? && current_user.id != @product.user.id %>
+<% elsif user_signed_in? %>   
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
 <% end %>
 
@@ -101,7 +99,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,54 +16,52 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @product.price %>
+        円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @product.deliver_fee.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+<% if user_signed_in? &&  current_user.id  == @product.user.id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+<% end %>
+   
+    <% if user_signed_in? && current_user.id != @product.user.id %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+<% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.state.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.deliver_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.shipment.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.shipment_day.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
#what
商品詳細ページの実装

#why
ユーザーが商品の購入をしたり、商品情報を編集、削除するため


ログイン状態の出品者が、自身の出品した販売中商品の詳細ページへ遷移した動画
・https://gyazo.com/9afc61473479269e24cbb9edb5b4988c

ログイン状態の出品者が、自身の出品した売却済み商品の詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
・購入機能未実装のため動画なし

ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移した動画
・https://gyazo.com/9a46a57318df3826581e35d40da7f8ab

ログイン状態の出品者以外のユーザーが、他者の出品した売却済み商品の詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
・購入機能未実装のため動画なし

ログアウト状態のユーザーが、商品詳細ページへ遷移した動画
・https://gyazo.com/343e9a9e152e7c4890ac523177fc51b5
